### PR TITLE
[SI-12]  feature/limit hp

### DIFF
--- a/src/main/java/engine/Core.java
+++ b/src/main/java/engine/Core.java
@@ -88,7 +88,7 @@ public final class Core {
 
 		int returnCode = 1;
 		do {
-			MAX_LIVES = wallet.getLives_lv()+2;
+			setLivesByDifficulty(DifficultySetting);
 			gameState = new GameState(1, 0, BASE_SHIP, MAX_LIVES, 0, 0, 0, "", 0, 0, 0 ,0, 0);
 			achievementManager = new AchievementManager();
 
@@ -310,5 +310,27 @@ public final class Core {
 
 	public static int getLevelSetting(){
 		return DifficultySetting;
+	}
+
+	/**
+	 * @param difficulty MAX_LIVES based on difficulty
+	 */
+	public static void setLivesByDifficulty(int difficulty) {
+		Wallet wallet = Wallet.getWallet();
+		switch (difficulty) {
+			case 0: // EASY
+				MAX_LIVES = wallet.getLives_lv() + 2;
+				break;
+			case 1: // NORMAL
+				if(wallet.getLives_lv() > 2) {
+					MAX_LIVES = 3;
+				} else {
+					MAX_LIVES = wallet.getLives_lv() + 1;
+				}
+				break;
+			case 2: // HARD
+				MAX_LIVES = 1;
+				break;
+		}
 	}
 }

--- a/src/test/java/engine/CoreTest.java
+++ b/src/test/java/engine/CoreTest.java
@@ -1,0 +1,67 @@
+package engine;
+
+import static org.junit.jupiter.api.Assertions.*;
+import entity.Wallet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CoreTest {
+    Wallet wallet;
+
+    @BeforeEach
+    public void setup() {
+        wallet = new Wallet();
+    }
+
+    // EASY
+    @Test
+    public void testMaxLivesEasy() {
+        // if livesLv is 1 test
+        wallet.setLives_lv(1); //livesLv = 1
+        Core.setLivesByDifficulty(0); // EASY
+        assertEquals(3, Core.MAX_LIVES, "Easy difficulty is wallet.getLives_lv() + 2");
+
+        // if livesLv is 3 test
+        wallet.setLives_lv(3); // livesLv = 3
+        Core.setLivesByDifficulty(0); // EASY
+        assertEquals(5, Core.MAX_LIVES, "Easy difficulty is wallet.getLives_lv() + 2");
+
+        // if livesLv is 4 test
+        wallet.setLives_lv(4); // livesLv = 4
+        Core.setLivesByDifficulty(0); // EASY
+        assertEquals(6, Core.MAX_LIVES, "Easy difficulty is wallet.getLives_lv() + 2");
+    }
+
+    //NORMAL
+    @Test
+    public void testMaxLivesNormal() {
+        // if livesLv is 1 test
+        wallet.setLives_lv(1); // livesLv = 1
+        Core.setLivesByDifficulty(1); // NORMAL
+        assertEquals(2, Core.MAX_LIVES, "Normal difficulty is wallet.getLives_lv() + 1");
+
+        // if livesLv is 2 test
+        wallet.setLives_lv(2); // livesLv = 2
+        Core.setLivesByDifficulty(1); // NORMAL
+        assertEquals(3, Core.MAX_LIVES, "Normal difficulty is wallet.getLives_lv() + 1");
+
+        // if livesLv is 3 test
+        wallet.setLives_lv(3); // livesLv = 3
+        Core.setLivesByDifficulty(1); // NORMAL
+        assertEquals(3, Core.MAX_LIVES, "If livesLv > 2 on NORMAL difficulty, MAX_LIVES must be 3");
+    }
+
+    // HARD
+    @Test
+    public void testMaxLivesHard() {
+        // if livesLv is 1 test
+        wallet.setLives_lv(1); // livesLv = 1
+        Core.setLivesByDifficulty(2); // HARD
+        assertEquals(1, Core.MAX_LIVES, "On HARD difficulty, MAX_LIVES should always be 1");
+
+        // if livesLv is 3 test
+        wallet.setLives_lv(3); // livesLv = 3
+        Core.setLivesByDifficulty(2); // HARD
+        assertEquals(1, Core.MAX_LIVES, "On HARD difficulty, MAX_LIVES should always be 1");
+    }
+}


### PR DESCRIPTION
## Summary
Adjusted the initial MAX_LIVES number based on the difficulty level.
easy = 3, normal = 2, hard = 1

When purchasing additional lives from the store, we limited the maximum health to full for EASY, 3 and 1 for NORMAL and HARD respectively.

## PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Code style changes (formatting, variable name, comments)
- [ ] Documentation content changes
- [x] Test related changes
- [ ] Build related changes
- [ ] Delete or rename a file or folder
- [ ] Other:

## Checklist
- [x] The commit message follows convention ([Guidelines](https://haesoo9410.tistory.com/300))
- [x] Tests for the changes have been conducted 
